### PR TITLE
loader: Try to handle ICD failure in vkEnumeratePhysicalDevices

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -6590,7 +6590,7 @@ VkResult setup_loader_term_phys_dev_groups(struct loader_instance *inst) {
                            "setup_loader_term_phys_dev_groups:  Failed during dispatch call of "
                            "\'EnumeratePhysicalDevices\' to ICD %d to get plain phys dev count.",
                            icd_idx);
-                goto out;
+                continue;
             }
         } else {
             // Query the actual group info
@@ -6600,10 +6600,11 @@ VkResult setup_loader_term_phys_dev_groups(struct loader_instance *inst) {
                            "setup_loader_term_phys_dev_groups:  Failed during dispatch call of "
                            "\'EnumeratePhysicalDeviceGroups\' to ICD %d to get count.",
                            icd_idx);
-                goto out;
+                continue;
             }
         }
         total_count += cur_icd_group_count;
+        
     }
 
     if (total_count == 0) {


### PR DESCRIPTION
If any ICD failed to enumerate device groups here, we would fail the call entirely, which means a broken driver for device A could prevent you from using device B. Just skip over the failing ICD instead.